### PR TITLE
adding flat PL plotting and option for gw red noise

### DIFF
--- a/la_forge/utils.py
+++ b/la_forge/utils.py
@@ -151,6 +151,15 @@ def compute_rho(log10_A, gamma, f, T):
                     * fyr**(gamma-3) * f**(-gamma) / T)
 
 
+def compute_rho_flat(log10_A, gamma, log10_B, f, T):
+    """
+    Converts from power to residual RMS.
+    """
+
+    return np.sqrt(((10**log10_A)**2 / (12.0*np.pi**2)
+                    * fyr**(gamma-3) * f**(-gamma) + 10**log10_B) / T)
+
+
 def convert_pal2_pars(p2_par):
     p2 = p2_par.split('_')
     psr = p2[-1]


### PR DESCRIPTION
Adding the flat powerlaw model for red noise and gw from `enterprise` + `enterprise_extensions`, see pull request there (https://github.com/nanograv/enterprise/pull/215 and https://github.com/nanograv/enterprise_extensions/pull/59).

Also, allows the plotting of gw as a red noise in `rednoise.plot_rednoise_spectrum` by using `pulsar=''` and `rn_types='gw'` options. Note, there are exceptions handling fixed gamma=4.33 runs, and requires setting `plot_2d_hist=False` to work.